### PR TITLE
Rename filedialog package to godialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TODO:
 - [x] Create test app
 - [x] Move fyne native implementation into separate package
 - [x] Do not vendor deps?
-- [ ] Rename filedialog package to dodialog
+- [x] Rename filedialog package to dodialog
 - [x] Move dbus to linux dialog file
 - [ ] Test with go-minesweeper
 - [ ] Test infraspace-...

--- a/dialog.go
+++ b/dialog.go
@@ -1,4 +1,4 @@
-package filedialog
+package godialog
 
 type DialogCallback func(string, error)
 

--- a/dialog_linux.go
+++ b/dialog_linux.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package filedialog
+package godialog
 
 import (
 	"fmt"

--- a/dialog_linux_test.go
+++ b/dialog_linux_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package filedialog
+package godialog
 
 import (
 	"testing"

--- a/dialog_test.go
+++ b/dialog_test.go
@@ -1,4 +1,4 @@
-package filedialog
+package godialog
 
 import (
 	"testing"

--- a/dialog_windows.go
+++ b/dialog_windows.go
@@ -1,6 +1,6 @@
 //go:build windows
 
-package filedialog
+package godialog
 
 import (
 	"fmt"

--- a/fallback/fyne/dialog.go
+++ b/fallback/fyne/dialog.go
@@ -6,7 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/storage"
-	filedialog "github.com/heathcliff26/godialog"
+	"github.com/heathcliff26/godialog"
 )
 
 const (
@@ -14,8 +14,8 @@ const (
 	DefaultDialogWidth  float32 = 600
 )
 
-// Ensure FyneFallbackDialog implements filedialog.FallbackDialog
-var _ filedialog.FallbackDialog = (*FyneFallbackDialog)(nil)
+// Ensure FyneFallbackDialog implements godialog.FallbackDialog
+var _ godialog.FallbackDialog = (*FyneFallbackDialog)(nil)
 
 // Opens a file dialog in a new fyne window for the given app.
 type FyneFallbackDialog struct {
@@ -33,7 +33,7 @@ func NewFyneFallbackDialog(app fyne.App) *FyneFallbackDialog {
 }
 
 // Shows the open file dialog and calls the callback asynchronously.
-func (f *FyneFallbackDialog) Open(title string, initialDirectory string, filters filedialog.FileFilters, cb filedialog.DialogCallback) {
+func (f *FyneFallbackDialog) Open(title string, initialDirectory string, filters godialog.FileFilters, cb godialog.DialogCallback) {
 	if f.App == nil {
 		go cb("", fmt.Errorf("cannot open file dialog: fyne.App is nil"))
 		return
@@ -52,7 +52,7 @@ func (f *FyneFallbackDialog) Open(title string, initialDirectory string, filters
 }
 
 // Shows the save file dialog and calls the callback asynchronously.
-func (f *FyneFallbackDialog) Save(title string, initialDirectory string, filters filedialog.FileFilters, cb filedialog.DialogCallback) {
+func (f *FyneFallbackDialog) Save(title string, initialDirectory string, filters godialog.FileFilters, cb godialog.DialogCallback) {
 	if f.App == nil {
 		go cb("", fmt.Errorf("cannot open file dialog: fyne.App is nil"))
 		return
@@ -70,7 +70,7 @@ func (f *FyneFallbackDialog) Save(title string, initialDirectory string, filters
 	}
 }
 
-func (f *FyneFallbackDialog) showFileDialog(initialDirectory string, filters filedialog.FileFilters, d *dialog.FileDialog, w fyne.Window) error {
+func (f *FyneFallbackDialog) showFileDialog(initialDirectory string, filters godialog.FileFilters, d *dialog.FileDialog, w fyne.Window) error {
 	d.SetFilter(storage.NewExtensionFileFilter(filters.Extensions()))
 
 	err := setDialogLocationToDir(initialDirectory, d)

--- a/fallback/fyne/dialog_test.go
+++ b/fallback/fyne/dialog_test.go
@@ -7,7 +7,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/test"
-	filedialog "github.com/heathcliff26/godialog"
+	"github.com/heathcliff26/godialog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +54,7 @@ func TestShowFileDialog(t *testing.T) {
 	w := a.NewWindow("Test")
 	d := dialog.NewFileOpen(func(uri fyne.URIReadCloser, err error) {}, w)
 
-	filters := filedialog.FileFilters{
+	filters := godialog.FileFilters{
 		{
 			Description: "Test",
 			Extensions:  []string{".txt"},

--- a/fallback/fyne/utils.go
+++ b/fallback/fyne/utils.go
@@ -6,7 +6,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/storage"
-	filedialog "github.com/heathcliff26/godialog"
+	"github.com/heathcliff26/godialog"
 )
 
 // Set a file dialogs location to the given directory.
@@ -31,7 +31,7 @@ type GenericURICloser interface {
 	URI() fyne.URI
 }
 
-func callCallback(cb filedialog.DialogCallback, uri GenericURICloser, err error) {
+func callCallback(cb godialog.DialogCallback, uri GenericURICloser, err error) {
 	if err != nil {
 		cb("", err)
 		return

--- a/filter.go
+++ b/filter.go
@@ -1,4 +1,4 @@
-package filedialog
+package godialog
 
 type FileFilter struct {
 	// A short description of this filter.

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,4 +1,4 @@
-package filedialog
+package godialog
 
 import (
 	"testing"

--- a/tests/app/main.go
+++ b/tests/app/main.go
@@ -9,7 +9,7 @@ import (
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/widget"
-	filedialog "github.com/heathcliff26/godialog"
+	"github.com/heathcliff26/godialog"
 	fyneFallback "github.com/heathcliff26/godialog/fallback/fyne"
 )
 
@@ -162,20 +162,20 @@ func main() {
 	w.ShowAndRun()
 }
 
-func prepFileDialog(startLocationText string, filterText string) filedialog.FileDialog {
+func prepFileDialog(startLocationText string, filterText string) godialog.FileDialog {
 	filters := parseFilters(filterText)
-	fd := filedialog.FileDialog{
+	fd := godialog.FileDialog{
 		InitialDirectory: startLocationText,
 	}
 	fd.SetFilters(filters)
 	return fd
 }
 
-func parseFilters(filterText string) filedialog.FileFilters {
+func parseFilters(filterText string) godialog.FileFilters {
 	if filterText == "" {
 		return nil
 	}
-	var filters filedialog.FileFilters
+	var filters godialog.FileFilters
 
 	for _, line := range strings.Split(filterText, "\n") {
 		s := strings.Split(line, ";")
@@ -183,7 +183,7 @@ func parseFilters(filterText string) filedialog.FileFilters {
 			appendLog(fmt.Sprintf("Invalid filter format: %s", line))
 			continue
 		}
-		filter := filedialog.FileFilter{
+		filter := godialog.FileFilter{
 			Description: s[0],
 			Extensions:  strings.Split(s[1], " "),
 		}


### PR DESCRIPTION
The legacy name ruins imports.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>