### PR TITLE
go.mod: Use go 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/godialog
 
-go 1.24.1
+go 1.24.0
 
 require (
 	fyne.io/fyne/v2 v2.6.1


### PR DESCRIPTION
No need to specify a patch version.