### PR TITLE
Prevent panic on malformed DBUS response

### DIFF
--- a/dialog_linux.go
+++ b/dialog_linux.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	DBusObjectName = "org.freedesktop.portal.Desktop"
-	DBusObjectPath = "/org/freedesktop/portal/desktop"
+	DBusObjectName   = "org.freedesktop.portal.Desktop"
+	DBusObjectPath   = "/org/freedesktop/portal/desktop"
+	DBusResponseName = "org.freedesktop.portal.Request.Response"
 
 	DBusFileChooserBase     = "org.freedesktop.portal.FileChooser"
 	DBusFileChooserOpenFile = ".OpenFile"
@@ -118,34 +119,87 @@ func dbusWaitForResponse() (string, error) {
 		return "", fmt.Errorf("failed to connect to session bus: %w", err)
 	}
 
-	err = conn.AddMatchSignal(
+	opts := []dbus.MatchOption{
 		dbus.WithMatchObjectPath(DBusObjectPath),
 		dbus.WithMatchInterface("org.freedesktop.portal.Request"),
 		dbus.WithMatchMember("Response"),
-	)
+	}
+
+	err = conn.AddMatchSignal(opts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to subscribe to response signal: %w", err)
 	}
+	defer func() {
+		_ = conn.RemoveMatchSignal(opts...)
+	}()
+
 	c := make(chan *dbus.Signal)
 	conn.Signal(c)
+	defer conn.RemoveSignal(c)
 
-	res := <-c
-	if len(res.Body) < 2 {
-		return "", fmt.Errorf("invalid response from dbus: %v", res.Body)
+	for res := range c {
+		slog.Debug("Received dbus signal", "signal", res)
+		path, ignored, err := parseDBusResponse(res)
+		if ignored {
+			continue
+		}
+		return path, err
 	}
-	if res.Body[0].(uint32) != 0 {
-		// User cancelled the dialog
-		return "", nil
+	return "", fmt.Errorf("dbus signal channel closed unexpectedly")
+}
+
+// Parse the incoming response from dbus.
+func parseDBusResponse(res *dbus.Signal) (path string, ignored bool, err error) {
+	if res == nil {
+		err = fmt.Errorf("received nil signal from dbus")
+		return
 	}
-	uris := res.Body[1].(map[string]dbus.Variant)["uris"].Value().([]string)
+
+	// Ignore random signals
+	if res.Name != DBusResponseName {
+		ignored = true
+		return
+	}
+
+	if len(res.Body) != 2 {
+		err = fmt.Errorf("invalid response from dbus, invalid response body: %v", res)
+		return
+	}
+	signal, ok := res.Body[0].(uint32)
+	if !ok {
+		err = fmt.Errorf("invalid response from dbus, no response signal: %v", res)
+		return
+	}
+
+	// Check if the user cancelled the dialog
+	if signal != 0 {
+		return
+	}
+
+	resultMap, ok := res.Body[1].(map[string]dbus.Variant)
+	if !ok {
+		err = fmt.Errorf("invalid response from dbus, no results: %v", res)
+		return
+	}
+	urisVariant, ok := resultMap["uris"]
+	if !ok {
+		err = fmt.Errorf("invalid response from dbus, no uris provided: %v", res)
+		return
+	}
+	uris, ok := urisVariant.Value().([]string)
+	if !ok {
+		err = fmt.Errorf("invalid response from dbus, uris have the wrong type: %v", res)
+		return
+	}
 	if len(uris) == 0 {
-		return "", nil
+		err = fmt.Errorf("response indicated success but no path was selected %v", res)
+		return
 	}
 
-	path, _ := strings.CutPrefix(uris[0], "file://")
+	path, _ = strings.CutPrefix(uris[0], "file://")
 	path, err = url.PathUnescape(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to unescape path: %w", err)
+		err = fmt.Errorf("failed to unescape path: %w", err)
 	}
-	return path, nil
+	return
 }

--- a/dialog_linux_test.go
+++ b/dialog_linux_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConvertFiltersToFreedesktopFilter(t *testing.T) {
@@ -77,4 +79,140 @@ func TestDialogDoesNotBlock(t *testing.T) {
 			t.Error("Dialog did not return in time")
 		}
 	})
+}
+
+func TestParseDBusResponse(t *testing.T) {
+	tMatrix := []struct {
+		Name          string
+		Input         *dbus.Signal
+		Path          string
+		ErrorContains string
+		Ignored       bool
+	}{
+		{
+			Name: "ValidResponse",
+			Input: &dbus.Signal{
+				Name: DBusResponseName,
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"uris": dbus.MakeVariant([]string{"file:///home/user/file.txt"}),
+					},
+				},
+			},
+			Path: "/home/user/file.txt",
+		},
+		{
+			Name:          "Nil",
+			ErrorContains: "received nil signal from dbus",
+		},
+		{
+			Name:          "InvlidBodyLength",
+			Input:         &dbus.Signal{Name: DBusResponseName, Body: []interface{}{uint32(0)}},
+			ErrorContains: "invalid response from dbus, invalid response body",
+		},
+		{
+			Name:          "NoResponseSignal",
+			Input:         &dbus.Signal{Name: DBusResponseName, Body: []interface{}{"not-a-number", "some other value"}},
+			ErrorContains: "invalid response from dbus, no response signal",
+		},
+		{
+			Name:  "Cancelled",
+			Input: &dbus.Signal{Name: DBusResponseName, Body: []interface{}{uint32(1), "some other value"}},
+		},
+		{
+			Name:          "NoResults",
+			Input:         &dbus.Signal{Name: DBusResponseName, Body: []interface{}{uint32(0), "some other value"}},
+			ErrorContains: "invalid response from dbus, no results",
+		},
+		{
+			Name: "NoUris",
+			Input: &dbus.Signal{
+				Name: DBusResponseName,
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"not-uris": dbus.MakeVariant([]string{"file:///home/user/file.txt"}),
+					},
+				},
+			},
+			ErrorContains: "invalid response from dbus, no uris provided",
+		},
+		{
+			Name: "UrisWrongType",
+			Input: &dbus.Signal{
+				Name: DBusResponseName,
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"uris": dbus.MakeVariant(0),
+					},
+				},
+			},
+			ErrorContains: "invalid response from dbus, uris have the wrong type",
+		},
+		{
+			Name: "NoUris",
+			Input: &dbus.Signal{
+				Name: DBusResponseName,
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"uris": dbus.MakeVariant([]string{}),
+					},
+				},
+			},
+			ErrorContains: "response indicated success but no path was selected",
+		},
+		{
+			Name: "MisformedPath",
+			Input: &dbus.Signal{
+				Name: DBusResponseName,
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"uris": dbus.MakeVariant([]string{"file:///%ÖÖ"}),
+					},
+				},
+			},
+			ErrorContains: "failed to unescape path",
+		},
+		{
+			Name: "WrongResponseName",
+			Input: &dbus.Signal{
+				Name: "NotTheResponse",
+				Body: []interface{}{
+					uint32(0),
+					map[string]dbus.Variant{
+						"uris": dbus.MakeVariant([]string{"file:///home/user/file.txt"}),
+					},
+				},
+			},
+			Ignored: true,
+		},
+	}
+
+	for _, tCase := range tMatrix {
+		t.Run(tCase.Name, func(t *testing.T) {
+			require := require.New(t)
+			var path string
+			var err error
+			var ignored bool
+			require.NotPanics(func() {
+				path, ignored, err = parseDBusResponse(tCase.Input)
+			}, "parseDBusResponse should not panic")
+			if tCase.Path != "" {
+				require.NoError(err, "Should not return an error")
+				require.Equal(tCase.Path, path, "Should return correct path")
+			} else if tCase.ErrorContains != "" {
+				require.Error(err, "Should return an error")
+				require.Empty(path, "should not return a path")
+				require.Contains(err.Error(), tCase.ErrorContains, "Error message should contain expected text")
+			} else {
+				require.NoError(err, "Should not return an error")
+				require.Empty(path, "should not return a path")
+				require.Equal(tCase.Ignored, ignored, "Should match expected ignore value")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Parse the DBUS response in more steps with prober error handling. Ignore signals that are not the response to our request.

Fixes: #36